### PR TITLE
`master` branch is renamed to `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
       - 'renovate/**'
 
   pull_request:
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
 
       - name: Docker registry login
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Publish
@@ -25,4 +25,4 @@ jobs:
           command: docker-builder
           major-minor: false
           prune: true
-          dry-run: ${{ github.ref != 'refs/heads/master' }}
+          dry-run: ${{ github.ref != 'refs/heads/main' }}

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 
 Dockerized Cocoapods command line tool
 
-This repository is the source for the Docker Hub image `renovate/cocoapods`. Commits to `master` branch are automatically built and published.
+This repository is the source for the Docker Hub image `renovate/cocoapods`. Commits to `main` branch are automatically built and published.


### PR DESCRIPTION
Due to this Docker Hub images were not updated recently.

https://hub.docker.com/r/renovate/cocoapods/tags?page=1&ordering=last_updated

![image](https://user-images.githubusercontent.com/909674/135189990-bea516b9-a8d2-4963-ba34-88f32affedd4.png)